### PR TITLE
remove bash engine since it is not portable

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -610,7 +610,7 @@ whoami
 </code></pre>
 
 
-```{r engine='bash'}
+```{r engine='bash', eval = FALSE}
 whoami
 ```
 


### PR DESCRIPTION
fix #2
